### PR TITLE
Add HACS default PR configuration for Tripp Lite SRCOOL integration

### DIFF
--- a/.cursor/rules/hacs-default-pr.mdc
+++ b/.cursor/rules/hacs-default-pr.mdc
@@ -1,0 +1,58 @@
+---
+description: HACS default repo PR for Tripp Lite SRCOOL (Shaffer-Softworks/Tripp-light)
+alwaysApply: false
+---
+
+# HACS Default Repository PR — Tripp-light
+
+## PR Details
+
+- **PR**: https://github.com/hacs/default/pull/7959
+- **Title**: Adds new integration [Shaffer-Softworks/Tripp-light]
+- **Fork**: https://github.com/sickkick/HACS (branch: `add-tripp-lite-srcool`)
+- **Target**: `hacs/default` → `master`
+- **Reviewer**: @ludeeus (HACS maintainer)
+
+## Repository Being Added
+
+- **Canonical repo (case-sensitive)**: `Shaffer-Softworks/Tripp-light` — https://github.com/Shaffer-Softworks/Tripp-light
+- **Do not use** `sickkick/Tripp-light` in `hacs/default` (reviewer flagged case/name mismatch)
+- **HACS file changed**: `integration` (JSON array, alphabetically sorted)
+- **Position**: after `Shaffer-Softworks/hyperhdr-ha`, before `shaiu/technicolor`
+
+```json
+"Shaffer-Softworks/Tripp-light",
+```
+
+## Workflow (fork sickkick/HACS)
+
+```bash
+git clone https://github.com/sickkick/HACS.git
+cd HACS
+git remote add upstream https://github.com/hacs/default.git
+git fetch upstream master
+git checkout -B add-tripp-lite-srcool upstream/master
+# edit integration — one line, exact repo name
+git commit -m "Adds new integration [Shaffer-Softworks/Tripp-light]"
+git push -u origin add-tripp-lite-srcool
+gh pr create --repo hacs/default --head sickkick:add-tripp-lite-srcool --base master
+gh pr ready <number> --repo hacs/default
+```
+
+## PR body checklist (integrations)
+
+- Publishing docs, HACS action, hassfest action, CI passing, release link, brand note for HA 2026.3+
+- Links: `https://github.com/Shaffer-Softworks/Tripp-light/releases/tag/v0.5.3`, latest Actions run on `main`
+
+## Brand assets
+
+- `custom_components/tripp_lite_srcool/brand/` — `icon.png`, `icon@2x.png`, `logo.png`, `logo@2x.png`
+- Not in `home-assistant/brands`; local `brand/` per HA 2026.3+ custom integration guidance
+
+## If PR breaks after upstream merges
+
+Same as Android-Management (#5854): rebase branch on `upstream/master`, re-add the single `integration` line if lost (0 additions/0 deletions), force-push, mark **ready for review** again.
+
+## Fix applied (2026-05-24)
+
+Reviewer: repository name must match GitHub exactly. Replaced `sickkick/Tripp-light` with `Shaffer-Softworks/Tripp-light` in `integration` and updated PR title/body/links.

--- a/.cursor/rules/tripp-light.mdc
+++ b/.cursor/rules/tripp-light.mdc
@@ -5,13 +5,19 @@ alwaysApply: true
 
 # Tripp-light (Tripp Lite SRCOOL)
 
-Home Assistant **custom integration** for the Tripp Lite **SRCOOLNET** SNMP Webcard Interface Module over Telnet. Does not support SRCOOL units without this adapter.
+Home Assistant **custom integration** for the Tripp Lite **SRCOOLNET** SNMP Webcard Interface Module over Telnet.
+
+## Supported hardware
+
+- **Required adapter:** [Tripp Lite SRCOOLNET](https://tripplite.eaton.com/snmp-webcard-interface-module-remote-cooling-management-srcool12k-srxcool12k~SRCOOLNET) — SNMP Webcard Interface Module for Remote Cooling Management (SRCOOL12K / SRXCOOL12K).
+- **Not supported:** Direct telnet to SRCOOL units without the SRCOOLNET adapter. Do **not** document or imply support for SRCOOLNETLX or generic SR(X)COOL units.
+- User-facing docs (`README.md`, `translations/en.json`) must name **SRCOOLNET** and link to the Eaton product page above.
 
 ## Distribution
 
-- **HACS custom repository only** — do **not** submit to `hacs/default` unless the user explicitly asks.
-- Repos: `https://github.com/sickkick/Tripp-light`, `Shaffer-Softworks/Tripp-light` (fork)
-- Users add via HACS → Integrations → Custom repositories → category **Integration**.
+- **Canonical GitHub repo:** [Shaffer-Softworks/Tripp-light](https://github.com/Shaffer-Softworks/Tripp-light) (case-sensitive; use this name in `hacs/default` PRs).
+- **HACS default inclusion:** open PR [hacs/default#7959](https://github.com/hacs/default/pull/7959) via fork `sickkick/HACS` branch `add-tripp-lite-srcool`. See `.cursor/rules/hacs-default-pr.mdc`.
+- Until merged: users add via HACS → Integrations → Custom repositories → URL `https://github.com/Shaffer-Softworks/Tripp-light`, category **Integration**.
 
 ## Repository layout
 
@@ -97,7 +103,7 @@ Python **3.11** on `ubuntu-latest`:
 
 Forks must set on GitHub or HACS validation fails:
 
-- **Description** (e.g. “Home Assistant custom integration for Tripp Lite SRCOOL…”)
+- **Description** (e.g. “Home Assistant custom integration for Tripp Lite SRCOOLNET Remote Cooling Management over Telnet.”)
 - **Topics:** `home-assistant`, `homeassistant`, `hacs`, `hacs-integration`
 
 ## When changing the integration
@@ -109,5 +115,5 @@ Forks must set on GitHub or HACS validation fails:
 
 ## Out of scope unless requested
 
-- PR to `hacs/default`
+- New or duplicate PRs to `hacs/default` (one open: #7959)
 - PR to `home-assistant/brands` (local `brand/` preferred for custom repo)

--- a/custom_components/tripp_lite_srcool/__init__.py
+++ b/custom_components/tripp_lite_srcool/__init__.py
@@ -8,7 +8,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
                                                       UpdateFailed)
 
-from .const import DIAGNOSTICS_REFRESH_INTERVAL, DOMAIN, SCAN_INTERVAL
+from .const import (DIAGNOSTIC_KEYS, DIAGNOSTICS_REFRESH_INTERVAL, DOMAIN,
+                    SCAN_INTERVAL)
 from .srcool_telnet import SRCOOLClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,7 +37,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 client.get_status,
                 include_diagnostics=include_diagnostics,
             )
-            return await hass.async_add_executor_job(fetch)
+            result = await hass.async_add_executor_job(fetch)
+            if not include_diagnostics and coordinator.data:
+                for key in DIAGNOSTIC_KEYS:
+                    if key in coordinator.data:
+                        result[key] = coordinator.data[key]
+            return result
         except ConnectionError as err:
             _LOGGER.warning(
                 "SRCOOL connection lost: %s – keeping old data", err)

--- a/custom_components/tripp_lite_srcool/const.py
+++ b/custom_components/tripp_lite_srcool/const.py
@@ -2,3 +2,14 @@ DOMAIN = 'tripp_lite_srcool'
 DEFAULT_PORT = 23
 SCAN_INTERVAL = 60
 DIAGNOSTICS_REFRESH_INTERVAL = 3600
+
+# Fetched from telnet menu 5; preserved between hourly refreshes.
+DIAGNOSTIC_KEYS = frozenset({
+    'os',
+    'agent_type',
+    'mac_address',
+    'card_serial_number',
+    'driver_version',
+    'engine_version',
+    'driver_file_status',
+})

--- a/custom_components/tripp_lite_srcool/manifest.json
+++ b/custom_components/tripp_lite_srcool/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/sickkick/Tripp-light/issues",
   "requirements": [],
-  "version": "0.5.3"
+  "version": "0.5.4"
 }

--- a/custom_components/tripp_lite_srcool/sensor.py
+++ b/custom_components/tripp_lite_srcool/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DIAGNOSTIC_KEYS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,16 +37,6 @@ SENSOR_TYPES: dict[str, tuple[str, str, str | None]] = {
     "driver_version": ("Driver Version", "mdi:numeric", None),
     "engine_version": ("Engine Version", "mdi:numeric", None),
     "driver_file_status": ("Driver File Status", _INFO, None),
-}
-
-DIAGNOSTIC_KEYS = {
-    "os",
-    "agent_type",
-    "mac_address",
-    "card_serial_number",
-    "driver_version",
-    "engine_version",
-    "driver_file_status",
 }
 
 


### PR DESCRIPTION
- Introduce a new markdown file for HACS default repository PR details, including integration specifics and workflow instructions.
- Update existing documentation to clarify the required adapter and supported hardware.
- Adjust the manifest version to 0.5.4 and enhance diagnostic handling in the integration code.
- Ensure consistency in naming conventions and repository references across documentation.