### PR TITLE
Refactor device info handling in SRCOOL integration

### DIFF
--- a/custom_components/tripp_lite_srcool/binary_sensor.py
+++ b/custom_components/tripp_lite_srcool/binary_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .device import build_device_info
 
 
 def _water_is_full(status: str | None) -> bool:
@@ -33,15 +34,7 @@ class SRCOOLWaterFullBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info shared with other platform entities."""
-        data = self.coordinator.data or {}
-        port = data.get("port_name") or "unknown_port"
-        return DeviceInfo(
-            identifiers={(DOMAIN, port)},
-            name=data.get("device_name") or "Tripp Lite SRCOOL",
-            manufacturer=data.get("vendor"),
-            model=data.get("product"),
-            sw_version=data.get("date_installed"),
-        )
+        return build_device_info(self.coordinator)
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/tripp_lite_srcool/climate.py
+++ b/custom_components/tripp_lite_srcool/climate.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .device import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,15 +60,7 @@ class SRCOOLClimate(CoordinatorEntity, ClimateEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device registry info for the SRCOOL device."""
-        data = self.coordinator.data or {}
-        port = data.get("port_name") or self._entry_id
-        return DeviceInfo(
-            identifiers={(DOMAIN, port)},
-            name=data.get("device_name") or f"Device {port}",
-            manufacturer=data.get("vendor"),
-            model=data.get("product"),
-            sw_version=data.get("date_installed"),
-        )
+        return build_device_info(self.coordinator)
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/custom_components/tripp_lite_srcool/device.py
+++ b/custom_components/tripp_lite_srcool/device.py
@@ -1,0 +1,64 @@
+"""Shared device registry info for SRCOOL entities."""
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN
+
+
+def _manufacturer(vendor: str | None) -> str | None:
+    if not vendor:
+        return None
+    if vendor.lower().replace(" ", "") == "tripplite":
+        return "Tripp Lite"
+    return vendor
+
+
+def _sw_version(data: dict) -> str | None:
+    for key in ("driver_version", "engine_version"):
+        version = data.get(key)
+        if version:
+            return version
+    return None
+
+
+def _serial_number(data: dict) -> str | None:
+    serial = data.get("serial_number")
+    if not serial or not serial.strip("0"):
+        return None
+    return serial
+
+
+def _device_name(data: dict) -> str:
+    name = data.get("device_name")
+    product = data.get("product")
+    if name and not name.startswith("Device "):
+        return name
+    if product:
+        return product
+    return "Tripp Lite SRCOOL"
+
+
+def build_device_info(coordinator) -> DeviceInfo:
+    """Build DeviceInfo from coordinator data and config entry."""
+    data = coordinator.data or {}
+    entry = coordinator.config_entry
+    port = data.get("port_name") or entry.entry_id
+
+    connections: set[tuple[str, str]] = set()
+    mac = data.get("mac_address")
+    if mac:
+        connections.add((CONNECTION_NETWORK_MAC, mac.upper()))
+
+    host = entry.data.get("host")
+    config_url = f"http://{host}" if host else None
+
+    return DeviceInfo(
+        identifiers={(DOMAIN, port)},
+        name=_device_name(data),
+        manufacturer=_manufacturer(data.get("vendor")),
+        model=data.get("product"),
+        sw_version=_sw_version(data),
+        serial_number=_serial_number(data),
+        configuration_url=config_url,
+        connections=connections or None,
+    )

--- a/custom_components/tripp_lite_srcool/manifest.json
+++ b/custom_components/tripp_lite_srcool/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/sickkick/Tripp-light/issues",
   "requirements": [],
-  "version": "0.5.5"
+  "version": "0.5.6"
 }

--- a/custom_components/tripp_lite_srcool/sensor.py
+++ b/custom_components/tripp_lite_srcool/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DIAGNOSTIC_KEYS, DOMAIN
+from .device import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,15 +86,7 @@ class SRCoolStatusSensor(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info shared with the climate entity."""
-        data = self.coordinator.data or {}
-        port = data.get("port_name") or "unknown_port"
-        return {
-            "identifiers": {(DOMAIN, port)},
-            "name": data.get("device_name") or "Tripp Lite SRCOOL",
-            "manufacturer": data.get("vendor"),
-            "model": data.get("product"),
-            "sw_version": data.get("date_installed"),
-        }
+        return build_device_info(self.coordinator)
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/tripp_lite_srcool/switch.py
+++ b/custom_components/tripp_lite_srcool/switch.py
@@ -6,6 +6,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .device import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,15 +38,7 @@ class SRCOOLDehumidifyingSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info shared with other platform entities."""
-        data = self.coordinator.data or {}
-        port = data.get("port_name") or "unknown_port"
-        return DeviceInfo(
-            identifiers={(DOMAIN, port)},
-            name=data.get("device_name") or "Tripp Lite SRCOOL",
-            manufacturer=data.get("vendor"),
-            model=data.get("product"),
-            sw_version=data.get("date_installed"),
-        )
+        return build_device_info(self.coordinator)
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
- Introduced a new `device.py` file to centralize device information construction for binary sensor, climate, sensor, and switch entities.
- Updated `device_info` properties across multiple entities to utilize the new `build_device_info` function, improving code maintainability and consistency.
- Incremented version number to 0.5.6 in the manifest file.