### PR TITLE
Update Tripp Lite SRCOOL integration configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,7 @@ jobs:
             echo ""
             echo "**Draft releases** use a temporary \`untagged-…\` URL in the job log until you **Publish** the release on GitHub; then the normal \`/releases/tag/${TAG}\` link applies."
             echo ""
-            echo "Release asset **\`tripp_lite_srcool.zip\`** (HACS \`zip_release\`) contains the integration files at the zip root (\`manifest.json\`, \`__init__.py\`, …); HACS unpacks them into \`custom_components/tripp_lite_srcool/\`."
+            echo "Release asset **\`tripp_lite_srcool.zip\`** contains the integration files at the zip root (\`manifest.json\`, \`__init__.py\`, …) for manual installs. After the first release with this asset, add \`zip_release\` and \`filename\` to \`hacs.json\` on \`${DEFAULT_BRANCH}\` so HACS downloads the zip (validation requires the latest release to include it)."
             echo ""
             echo "### PR checks"
             echo "If required checks were stuck: GitHub often **does not run** \`pull_request\` workflows for commits pushed with the default \`GITHUB_TOKEN\`. This workflow **dispatches Validate** on the release branch when secret \`WORKFLOW_TRIGGER_TOKEN\` is unset. Optionally add that repo secret (PAT with **contents** + **pull requests**, and **actions** if you use fine-grained) so push/PR use a non-GitHub Actions identity and checks start automatically like a normal PR."

--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,5 @@
 {
-  "hacs": "1.34.0",
   "name": "Tripp Lite SRCOOL",
   "homeassistant": "2024.9.0",
-  "render_readme": true,
-  "zip_release": true,
-  "filename": "tripp_lite_srcool.zip"
+  "render_readme": true
 }


### PR DESCRIPTION
- Remove version number and zip_release configuration from hacs.json.
- Update release workflow documentation for manual installs and future HACS integration.