### PR TITLE
Merge v0.5.9 manifest bump

### DIFF
--- a/custom_components/tripp_lite_srcool/manifest.json
+++ b/custom_components/tripp_lite_srcool/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "tripp_lite_srcool",
   "name": "Tripp Lite SRCOOL",
-  "codeowners": ["@sickkick"],
+  "codeowners": [
+    "@sickkick"
+  ],
   "config_flow": true,
   "documentation": "https://github.com/Shaffer-Softworks/Tripp-light",
   "iot_class": "local_polling",


### PR DESCRIPTION
Automated manifest bump for [v0.5.9](https://github.com/Shaffer-Softworks/Tripp-light/releases/tag/v0.5.9). Merge so `main` matches the release.

Made with [Cursor](https://cursor.com)