### PR TITLE
Merge v0.5.10 manifest bump

### DIFF
--- a/custom_components/tripp_lite_srcool/manifest.json
+++ b/custom_components/tripp_lite_srcool/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Shaffer-Softworks/Tripp-light/issues",
   "requirements": [],
-  "version": "0.5.9"
+  "version": "0.5.10"
 }


### PR DESCRIPTION
## Summary
- Automated manifest bump for [v0.5.10](https://github.com/Shaffer-Softworks/Tripp-light/releases/tag/v0.5.10).
- Includes fan mode fix: report `auto` when Auto Fan Speed is on.

## Test plan
- [x] Live telnet verification on SRCOOLNET at 10.10.0.61
- [x] `flake8` / `isort` on `custom_components/tripp_lite_srcool/`

Made with [Cursor](https://cursor.com)