### PR TITLE
Merge v1.0.0 manifest bump

### DIFF
--- a/custom_components/tripp_lite_srcool/manifest.json
+++ b/custom_components/tripp_lite_srcool/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Shaffer-Softworks/Tripp-light/issues",
   "requirements": [],
-  "version": "0.5.10"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Automated manifest bump for [v1.0.0](https://github.com/Shaffer-Softworks/Tripp-light/releases/tag/v1.0.0). Merge after checks pass so `main` matches the release.

Opened manually after Create release workflow failed on `gh pr create` (GITHUB_TOKEN cannot create PRs until `WORKFLOW_TRIGGER_TOKEN` is configured).

Made with [Cursor](https://cursor.com)