### PR TITLE
Merge v1.0.1 manifest bump

### DIFF
--- a/custom_components/tripp_lite_srcool/manifest.json
+++ b/custom_components/tripp_lite_srcool/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "telnetlib3>=4.0.0"
   ],
-  "version": "0.6.1"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Automated manifest bump for [v1.0.1](https://github.com/Shaffer-Softworks/Tripp-light/releases/tag/v1.0.1). Merge after checks pass so `main` matches the release.

Includes MIT LICENSE at repo root for HACS default catalog validation.

Made with [Cursor](https://cursor.com)